### PR TITLE
Allow running only with TravelTime

### DIFF
--- a/src/traveltime_drive_time_comparisons/config.py
+++ b/src/traveltime_drive_time_comparisons/config.py
@@ -122,11 +122,6 @@ def parse_json_to_providers(json_data: str) -> Providers:
             )
             competitors.append(competitor)
 
-    if len(competitors) == 0:
-        raise ValueError(
-            "There should be at least one enabled API provider that's not TravelTime."
-        )
-
     return Providers(base=base_provider, competitors=competitors)
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -81,12 +81,16 @@ def test_json_config_parse_all_disabled_providers():
         }
     """
 
-    with pytest.raises(ValueError) as excinfo:
-        _ = parse_json_to_providers(json)
+    providers = parse_json_to_providers(json)
 
-    assert (
-        str(excinfo.value)
-        == "There should be at least one enabled API provider that's not TravelTime."
+    assert providers == Providers(
+        base=Provider(
+            name="traveltime",
+            max_rpm=60,
+            credentials=Credentials(app_id="<your-app-id>", api_key="<your-api-key>"),
+            api_endpoint=None,
+        ),
+        competitors=[],
     )
 
 
@@ -102,10 +106,14 @@ def test_json_config_parse_empty_providers():
         }
     """
 
-    with pytest.raises(ValueError) as excinfo:
-        _ = parse_json_to_providers(json)
+    providers = parse_json_to_providers(json)
 
-    assert (
-        str(excinfo.value)
-        == "There should be at least one enabled API provider that's not TravelTime."
+    assert providers == Providers(
+        base=Provider(
+            name="traveltime",
+            max_rpm=60,
+            credentials=Credentials(app_id="<your-app-id>", api_key="<your-api-key>"),
+            api_endpoint=None,
+        ),
+        competitors=[],
     )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,3 @@
-import pytest
-
 from traveltime_drive_time_comparisons.config import (
     Provider,
     Providers,


### PR DESCRIPTION
We have a legitimate use case for collecting only TravelTime results and not relying on other providers 